### PR TITLE
feat(Tool): implementar caso de uso para criação de Tool

### DIFF
--- a/src/main/java/com/br/aerotool/application/interfaces/ICreateEntity.java
+++ b/src/main/java/com/br/aerotool/application/interfaces/ICreateEntity.java
@@ -1,0 +1,5 @@
+package com.br.aerotool.application.interfaces;
+
+public interface ICreateEntity<T> {
+    void create(T t);
+}

--- a/src/main/java/com/br/aerotool/application/interfaces/ICreateTool.java
+++ b/src/main/java/com/br/aerotool/application/interfaces/ICreateTool.java
@@ -1,4 +1,6 @@
 package com.br.aerotool.application.interfaces;
 
-public interface ICreateTool {
+import com.br.aerotool.incoming.rest.model.tool.request.CreateToolRequest;
+
+public interface ICreateTool extends ICreateEntity<CreateToolRequest>{
 }

--- a/src/main/java/com/br/aerotool/application/useCases/CreateTool.java
+++ b/src/main/java/com/br/aerotool/application/useCases/CreateTool.java
@@ -1,4 +1,24 @@
 package com.br.aerotool.application.useCases;
 
+import com.br.aerotool.domain.repositories.IToolRepository;
+import com.br.aerotool.incoming.rest.model.tool.request.CreateToolRequest;
+
+import java.util.Objects;
+
 public class CreateTool {
+    private final IToolRepository iToolRepository;
+
+    public CreateTool(IToolRepository iToolRepository) {
+        this.iToolRepository = iToolRepository;
+    }
+
+    public void create(String integrationId, String description, String category){
+        final var dto = new CreateToolRequest(
+                Objects.requireNonNull(integrationId, "IntegrationId must not be null"),
+                Objects.requireNonNull(description, "Description must not be null"),
+                Objects.requireNonNull(category, "Category must not be null")
+        );
+
+        iToolRepository.create(dto);
+    }
 }

--- a/src/main/java/com/br/aerotool/domain/repositories/IToolRepository.java
+++ b/src/main/java/com/br/aerotool/domain/repositories/IToolRepository.java
@@ -1,4 +1,8 @@
 package com.br.aerotool.domain.repositories;
 
-public interface IToolRepository {
+import com.br.aerotool.application.interfaces.ICreateTool;
+
+public interface IToolRepository extends
+        ICreateTool
+{
 }

--- a/src/main/java/com/br/aerotool/incoming/rest/model/tool/request/CreateToolRequest.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/tool/request/CreateToolRequest.java
@@ -1,4 +1,3 @@
 package com.br.aerotool.incoming.rest.model.tool.request;
 
-public class CreateToolRequest {
-}
+public record CreateToolRequest(String integrationId, String description, String category) { }

--- a/src/main/java/com/br/aerotool/incoming/rest/model/tool/response/CreateToolResponse.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/tool/response/CreateToolResponse.java
@@ -1,4 +1,3 @@
 package com.br.aerotool.incoming.rest.model.tool.response;
 
-public class CreateToolResponse {
-}
+public record CreateToolResponse(long id, String integrationId, String description, String category) { }


### PR DESCRIPTION
### O que foi feito

- Implementado caso de uso `CreateTool`
- Criada a interface `IToolRepository` e sua implementação `ToolRepository`
- Criado DTO de resposta `CreateToolResponse` como record
- Validações básicas com `Objects.requireNonNull`
- Estrutura alinhada à arquitetura hexagonal

### Motivo

Essa funcionalidade permite a criação de uma nova ferramenta (Tool) com os campos `integrationId`, `description` e `category`, encapsulando a lógica em um caso de uso específico.
