### PR TITLE
refactor: Modificando os métodos dos Enums para melhor qualidade de uso

### DIFF
--- a/src/main/java/com/br/aerotool/domain/entities/tool/ToolCategory.java
+++ b/src/main/java/com/br/aerotool/domain/entities/tool/ToolCategory.java
@@ -1,5 +1,9 @@
 package com.br.aerotool.domain.entities.tool;
 
+import lombok.Getter;
+import org.apache.coyote.BadRequestException;
+
+@Getter
 public enum ToolCategory {
     MANUAL("manual", "ferramentas manuais"),
     ELETRICA("electrica", "ferramentas conectadas à rede ou bateria"),
@@ -7,14 +11,22 @@ public enum ToolCategory {
     MEDICAO("medicao", "ferramentas usadas para medir distâncias");
 
     private final String name;
-    private String description;
+    private final String description;
 
     ToolCategory(String name, String description){
         this.name = name;
         this.description = description;
     }
 
-    public ToolCategory getToolCategory(String name){
-        return ToolCategory.valueOf(name);
+    public static ToolCategory getToolCategory(String name) throws BadRequestException {
+        if (name == null || name.isBlank()) {
+            throw new BadRequestException("Input may not be empty");
+        }
+        String key = name.trim().toUpperCase();
+        try {
+            return ToolCategory.valueOf(key);
+        }catch (IllegalArgumentException e){
+            throw new BadRequestException("Invalid Tool Category: "+ name);
+        }
     }
 }

--- a/src/main/java/com/br/aerotool/domain/entities/tool/ToolItemStatus.java
+++ b/src/main/java/com/br/aerotool/domain/entities/tool/ToolItemStatus.java
@@ -1,5 +1,9 @@
 package com.br.aerotool.domain.entities.tool;
 
+import lombok.Getter;
+import org.apache.coyote.BadRequestException;
+
+@Getter
 public enum ToolItemStatus {
     FUNCIONAL("funcional", "ferramenta utilizável"),
     MANUTENCAO("manutencao", "ferramenta em manutenção"),
@@ -7,14 +11,22 @@ public enum ToolItemStatus {
     DEFEITUOSA("defeituosa", "ferramenta defeituosa");
 
     private final String name;
-    private String description;
+    private final String description;
 
     ToolItemStatus(String name, String description){
         this.name = name;
         this.description = description;
     }
 
-    public ToolCategory getToolItemStatus(String name){
-        return ToolCategory.valueOf(name);
+    public static ToolItemStatus getToolItemStatus(String name) throws BadRequestException {
+        if (name == null || name.isBlank()) {
+            throw new BadRequestException("Input may not be empty");
+        }
+        String key = name.trim().toUpperCase();
+        try {
+            return ToolItemStatus.valueOf(key);
+        }catch (IllegalArgumentException e){
+            throw new BadRequestException("Invalid ToolItem Status: "+ name);
+        }
     }
 }

--- a/src/main/java/com/br/aerotool/domain/entities/user/User.java
+++ b/src/main/java/com/br/aerotool/domain/entities/user/User.java
@@ -5,7 +5,7 @@ import lombok.*;
 import java.util.Objects;
 
 @Getter
-public class User {
+public class User{
     private final String prontuario;
     @Setter
     private String password;

--- a/src/main/java/com/br/aerotool/incoming/rest/model/mapper/ToolMapper.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/mapper/ToolMapper.java
@@ -4,15 +4,16 @@ import com.br.aerotool.domain.entities.tool.Tool;
 import com.br.aerotool.domain.entities.tool.ToolCategory;
 import com.br.aerotool.incoming.rest.model.tool.request.ToolRequest;
 import com.br.aerotool.incoming.rest.model.tool.response.ToolResponse;
+import org.apache.coyote.BadRequestException;
 
 public class ToolMapper {
 
-    public static Tool toEntity(ToolRequest request){
+    public static Tool toEntity(ToolRequest request) throws BadRequestException {
         return new Tool(
                 -1L,
                 request.integrationId(),
                 request.description(),
-                ToolCategory.valueOf(request.category()),
+                ToolCategory.getToolCategory(request.category()),
                 null
         );
     }


### PR DESCRIPTION
Métodos `get<Enum>` agora tem implementações mais complexas com validações de parâmetros;
Adicionado exceptions `BadRequestException` em todos os métogos `get<Enum>`;
Em ToolMapper, adicionado `BadRequestException`;