### PR TITLE
Crud de useCases + modificação de Entidade e records

### DIFF
--- a/src/main/java/com/br/aerotool/application/interfaces/user/IReadUser.java
+++ b/src/main/java/com/br/aerotool/application/interfaces/user/IReadUser.java
@@ -2,6 +2,10 @@ package com.br.aerotool.application.interfaces.user;
 
 import com.br.aerotool.application.interfaces.IReadEntity;
 import com.br.aerotool.domain.entities.user.User;
+import com.br.aerotool.incoming.rest.model.user.request.UserFilterRequest;
+
+import java.util.List;
 
 public interface IReadUser extends IReadEntity<User, String> {
+    List<User> findAll(UserFilterRequest filter);
 }

--- a/src/main/java/com/br/aerotool/application/interfaces/user/IUpdateUser.java
+++ b/src/main/java/com/br/aerotool/application/interfaces/user/IUpdateUser.java
@@ -1,7 +1,7 @@
 package com.br.aerotool.application.interfaces.user;
 
 import com.br.aerotool.application.interfaces.IUpdateEntity;
-import com.br.aerotool.incoming.rest.model.user.response.UserResponse;
+import com.br.aerotool.incoming.rest.model.user.request.UserRequest;
 
-public interface IUpdateUser extends IUpdateEntity<UserResponse> {
+public interface IUpdateUser extends IUpdateEntity<UserRequest> {
 }

--- a/src/main/java/com/br/aerotool/application/useCases/user/CreateUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/CreateUser.java
@@ -2,9 +2,11 @@ package com.br.aerotool.application.useCases.user;
 
 import com.br.aerotool.domain.repositories.IUserRepository;
 import com.br.aerotool.incoming.rest.model.user.request.UserRequest;
+import org.springframework.stereotype.Service;
 
 import static java.util.Map.entry;
 
+@Service
 public class CreateUser {
     private final IUserRepository userRepository;
 

--- a/src/main/java/com/br/aerotool/application/useCases/user/DeleteUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/DeleteUser.java
@@ -3,11 +3,13 @@ package com.br.aerotool.application.useCases.user;
 import com.br.aerotool.domain.entities.user.User;
 import com.br.aerotool.domain.repositories.IUserRepository;
 import org.apache.coyote.BadRequestException;
+import org.springframework.stereotype.Service;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 
+@Service
 public class DeleteUser {
     private final IUserRepository userRepository;
 

--- a/src/main/java/com/br/aerotool/application/useCases/user/DeleteUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/DeleteUser.java
@@ -1,0 +1,28 @@
+package com.br.aerotool.application.useCases.user;
+
+import com.br.aerotool.domain.entities.user.User;
+import com.br.aerotool.domain.repositories.IUserRepository;
+import org.apache.coyote.BadRequestException;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DeleteUser {
+    private final IUserRepository userRepository;
+
+    public DeleteUser(IUserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void delete(String prontuario){
+        Objects.requireNonNull(prontuario, "prontuario must not be null");
+        if(prontuario.isBlank()) throw new IllegalArgumentException("prontuario must not be blank");
+
+        Optional<User> maybeUser = userRepository.findById(prontuario);
+        if(maybeUser.isEmpty()) throw new NoSuchElementException("User not found. Prontuario: " + prontuario);
+        User user = maybeUser.get();
+        user.markAsDeleted();
+        userRepository.delete(prontuario);
+    }
+}

--- a/src/main/java/com/br/aerotool/application/useCases/user/InputUtils.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/InputUtils.java
@@ -1,0 +1,17 @@
+package com.br.aerotool.application.useCases.user;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class InputUtils {
+    @SafeVarargs
+    static void notBlank(Entry<String, String>... fields){
+        for (Entry<String, String> entry : fields){
+            String name =  entry.getKey();
+            String value = entry.getValue();
+            if (value == null || value.isBlank()){
+                throw new IllegalArgumentException(name+" must not be null or blank");
+            }
+        }
+    }
+}

--- a/src/main/java/com/br/aerotool/application/useCases/user/ReadUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/ReadUser.java
@@ -1,0 +1,34 @@
+package com.br.aerotool.application.useCases.user;
+
+import com.br.aerotool.domain.entities.user.User;
+import com.br.aerotool.domain.repositories.IUserRepository;
+import com.br.aerotool.incoming.rest.model.user.request.UserFilterRequest;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ReadUser {
+    private final IUserRepository userRepository;
+
+    public ReadUser(IUserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public Optional<User> findById(String prontuario){
+        Objects.requireNonNull(prontuario, "prontuario must not be null");
+        if(prontuario.isBlank()) throw new IllegalArgumentException("prontuario must not be blank");
+
+        return userRepository.findById(prontuario);
+    }
+
+    public List<User> findAll(String role, int page, int size){
+        if (page < 0) throw new IllegalArgumentException("Page must be greater than or equal 0");
+        if (size <= 0) throw new IllegalArgumentException("Size must be greater than 0");
+
+        int offset = page * size;
+        String filterRole = role != null && !role.isBlank() ? role.toUpperCase() : null;
+
+        return userRepository.findAll(new UserFilterRequest(filterRole, page, size));
+    }
+}

--- a/src/main/java/com/br/aerotool/application/useCases/user/ReadUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/ReadUser.java
@@ -3,11 +3,13 @@ package com.br.aerotool.application.useCases.user;
 import com.br.aerotool.domain.entities.user.User;
 import com.br.aerotool.domain.repositories.IUserRepository;
 import com.br.aerotool.incoming.rest.model.user.request.UserFilterRequest;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+@Service
 public class ReadUser {
     private final IUserRepository userRepository;
 

--- a/src/main/java/com/br/aerotool/application/useCases/user/UpdateUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/UpdateUser.java
@@ -2,11 +2,13 @@ package com.br.aerotool.application.useCases.user;
 
 import com.br.aerotool.domain.repositories.IUserRepository;
 import com.br.aerotool.incoming.rest.model.user.request.UserRequest;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
 import static java.util.Map.entry;
 
+@Service
 public class UpdateUser {
     private final IUserRepository userRepository;
 

--- a/src/main/java/com/br/aerotool/application/useCases/user/UpdateUser.java
+++ b/src/main/java/com/br/aerotool/application/useCases/user/UpdateUser.java
@@ -3,16 +3,18 @@ package com.br.aerotool.application.useCases.user;
 import com.br.aerotool.domain.repositories.IUserRepository;
 import com.br.aerotool.incoming.rest.model.user.request.UserRequest;
 
+import java.time.LocalDateTime;
+
 import static java.util.Map.entry;
 
-public class CreateUser {
+public class UpdateUser {
     private final IUserRepository userRepository;
 
-    public CreateUser(IUserRepository userRepository) {
+    public UpdateUser(IUserRepository userRepository) {
         this.userRepository = userRepository;
     }
-    
-    public void create(String prontuario, String password, String name, String email, String document){
+
+    public void update(String prontuario, String password, String name, String email, String document, String role, LocalDateTime deletedAt){
         InputUtils.notBlank(
                 entry("prontuario", prontuario),
                 entry("password", password),
@@ -20,6 +22,6 @@ public class CreateUser {
                 entry("email", email),
                 entry("document", document)
         );
-        userRepository.create(new UserRequest(prontuario, password, name, email, document));
+        userRepository.update(new UserRequest(prontuario, password, name, email, document));
     }
 }

--- a/src/main/java/com/br/aerotool/domain/entities/user/User.java
+++ b/src/main/java/com/br/aerotool/domain/entities/user/User.java
@@ -14,24 +14,27 @@ public class User{
     private String name;
     @Setter
     private String email;
+    private final String document;
     @Setter
     private Role role;
     private LocalDateTime deletedAt;
 
-    public User(String prontuario, String password, String name, String email, Role role, LocalDateTime deletedAt) {
+    public User(String prontuario, String password, String name, String email, String document, Role role, LocalDateTime deletedAt) {
         this.prontuario = prontuario;
         this.password = password;
         this.name = name;
         this.email = email;
+        this.document = document;
         this.role = role;
         this.deletedAt = deletedAt;
     }
 
-    public User(String prontuario, String password, String name, String email) {
+    public User(String prontuario, String password, String name, String email, String document) {
         this.prontuario = prontuario;
         this.password = password;
         this.name = name;
         this.email = email;
+        this.document = document;
     }
 
     public void markAsDeleted() {

--- a/src/main/java/com/br/aerotool/incoming/rest/model/mapper/UserMapper.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/mapper/UserMapper.java
@@ -1,4 +1,40 @@
 package com.br.aerotool.incoming.rest.model.mapper;
 
+import com.br.aerotool.domain.entities.user.Role;
+import com.br.aerotool.domain.entities.user.User;
+import com.br.aerotool.incoming.rest.model.user.request.UserRequest;
+import com.br.aerotool.incoming.rest.model.user.response.UserResponse;
+import org.apache.coyote.BadRequestException;
+
 public class UserMapper {
+    public static User requestToEntity(UserRequest userRequest) {
+        return new User(
+                userRequest.prontuario(),
+                userRequest.password(),
+                userRequest.name(),
+                userRequest.email(),
+                userRequest.document()
+        );
+    }
+
+    public static UserResponse entityToResponse(User user){
+        return new UserResponse(
+                user.getProntuario(),
+                user.getName(),
+                user.getEmail(),
+                user.getDocument(),
+                user.getRole().getName(),
+                user.getDeletedAt()
+        );
+    }
+
+    public static UserRequest entityToRequest(User user){
+        return new UserRequest(
+                user.getProntuario(),
+                user.getPassword(),
+                user.getName(),
+                user.getEmail(),
+                user.getDocument()
+        );
+    }
 }

--- a/src/main/java/com/br/aerotool/incoming/rest/model/mapper/UserMapper.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/mapper/UserMapper.java
@@ -1,0 +1,4 @@
+package com.br.aerotool.incoming.rest.model.mapper;
+
+public class UserMapper {
+}

--- a/src/main/java/com/br/aerotool/incoming/rest/model/user/request/UserFilterRequest.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/user/request/UserFilterRequest.java
@@ -1,0 +1,4 @@
+package com.br.aerotool.incoming.rest.model.user.request;
+
+public class UserFilterRequest {
+}

--- a/src/main/java/com/br/aerotool/incoming/rest/model/user/request/UserFilterRequest.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/user/request/UserFilterRequest.java
@@ -1,4 +1,4 @@
 package com.br.aerotool.incoming.rest.model.user.request;
 
-public class UserFilterRequest {
+public record UserFilterRequest (String role, int page, int size){
 }

--- a/src/main/java/com/br/aerotool/incoming/rest/model/user/request/UserRequest.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/user/request/UserRequest.java
@@ -1,4 +1,8 @@
 package com.br.aerotool.incoming.rest.model.user.request;
 
-public record UserRequest(String prontuario, String password, String name, String email) {
+public record UserRequest(String prontuario,
+                          String password,
+                          String name,
+                          String email,
+                          String document) {
 }

--- a/src/main/java/com/br/aerotool/incoming/rest/model/user/response/UserResponse.java
+++ b/src/main/java/com/br/aerotool/incoming/rest/model/user/response/UserResponse.java
@@ -6,5 +6,6 @@ public record UserResponse (String prontuario,
                             String name,
                             String email,
                             String role,
+                            String document,
                             LocalDateTime deletedAt){
 }


### PR DESCRIPTION
Criação dos useCases e interfaces de Create, Read, Update e Delete Users;
Criação de um `InputUtils` para evitar repetição de código;
Criação de `UserFilterRequest `para paginação que será feita via SQL em próximas etapas;
Modificação de `User `e de seus Records com o novo atributo `document`;
Remoção do atributo `password `do Record `UserResponse `porque não fazia sentido.